### PR TITLE
settings-page-updates

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="tech.jaredezz.kaleidoku">
+
+    <queries>
+      <intent>
+        <action android:name="android.intent.action.SENDTO" />
+        <data android:scheme="mailto" />
+      </intent>
+    </queries>
    <application
         android:label="kaleidoku"
         android:icon="@mipmap/ic_launcher">

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,21 +1,27 @@
 PODS:
   - Flutter (1.0.0)
+  - flutter_email_sender (0.0.1):
+    - Flutter
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
+  - flutter_email_sender (from `.symlinks/plugins/flutter_email_sender/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
 
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
+  flutter_email_sender:
+    :path: ".symlinks/plugins/flutter_email_sender/ios"
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
 
 SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
+  flutter_email_sender: 02d7443217d8c41483223627972bfdc09f74276b
   path_provider_foundation: 29f094ae23ebbca9d3d0cec13889cd9060c0e943
 
 PODFILE CHECKSUM: b17e1ecfe97aba85f3997d462fe23d9e4313a8d8

--- a/lib/core/utils/app_theme.dart
+++ b/lib/core/utils/app_theme.dart
@@ -1,0 +1,108 @@
+// import 'package:flutter/material.dart';
+
+// abstract class AppTheme {
+//   static ThemeData get lightTheme {
+//     return ThemeData.light().copyWith(
+//       scaffoldBackgroundColor: Colors.white,
+//       primaryColor: Colors.blue,
+//       appBarTheme: AppBarTheme(
+//         color: Colors.white,
+//         iconTheme: IconThemeData(color: Colors.black),
+//         actionsIconTheme: IconThemeData(color: Colors.black),
+//       ),
+//       textTheme: TextTheme(
+//         headline1: TextStyle(color: Colors.black),
+//         headline2: TextStyle(color: Colors.black),
+//         headline3: TextStyle(color: Colors.black),
+//         headline4: TextStyle(color: Colors.black),
+//         headline5: TextStyle(color: Colors.black),
+//         headline6: TextStyle(color: Colors.black),
+//         subtitle1: TextStyle(color: Colors.black87),
+//         subtitle2: TextStyle(color: Colors.black54),
+//         bodyText1: TextStyle(color: Colors.black87),
+//         bodyText2: TextStyle(color: Colors.black54),
+//         caption: TextStyle(color: Colors.black38),
+//         button: TextStyle(color: Colors.white),
+//         overline: TextStyle(color: Colors.black26),
+//       ),
+//       buttonTheme: ButtonThemeData(
+//         buttonColor: Colors.blue,
+//         textTheme: ButtonTextTheme.primary,
+//       ),
+//       iconTheme: IconThemeData(
+//         color: Colors.black87,
+//       ),
+//       tabBarTheme: TabBarTheme(
+//         labelColor: Colors.blue,
+//         unselectedLabelColor: Colors.black38,
+//       ),
+//       inputDecorationTheme: InputDecorationTheme(
+//         border: OutlineInputBorder(),
+//         focusedBorder: OutlineInputBorder(
+//           borderSide: BorderSide(color: Colors.blue, width: 2.0),
+//         ),
+//         labelStyle: TextStyle(color: Colors.black87),
+//         hintStyle: TextStyle(color: Colors.black38),
+//       ),
+//       sliderTheme: SliderThemeData(
+//         activeTrackColor: Colors.blue,
+//         inactiveTrackColor: Colors.black26,
+//         thumbColor: Colors.blue,
+//       ),
+
+//       toggleableActiveColor: Colors.blueAccent,
+//       // ... and any other properties you might want to override.
+//     );
+//   }
+
+//   static ThemeData get darkTheme {
+//     return ThemeData.dark().copyWith(
+//       scaffoldBackgroundColor: Colors.grey.shade900,
+//       primaryColor: Colors.blueGrey,
+//       appBarTheme: AppBarTheme(
+//         color: Colors.grey.shade900,
+//       ),
+//       textTheme: const TextTheme(
+//         headline1: TextStyle(color: Colors.white),
+//         headline2: TextStyle(color: Colors.white),
+//         headline3: TextStyle(color: Colors.white),
+//         headline4: TextStyle(color: Colors.white),
+//         headline5: TextStyle(color: Colors.white),
+//         headline6: TextStyle(color: Colors.white),
+//         subtitle1: TextStyle(color: Colors.white70),
+//         subtitle2: TextStyle(color: Colors.white54),
+//         bodyText1: TextStyle(color: Colors.white),
+//         bodyText2: TextStyle(color: Colors.white70),
+//         caption: TextStyle(color: Colors.white54),
+//         button: TextStyle(color: Colors.white70),
+//         overline: TextStyle(color: Colors.white30),
+//       ),
+//       buttonTheme: ButtonThemeData(
+//         buttonColor: Colors.blueGrey,
+//         textTheme: ButtonTextTheme.primary,
+//       ),
+//       iconTheme: IconThemeData(
+//         color: Colors.white70,
+//       ),
+//       tabBarTheme: TabBarTheme(
+//         labelColor: Colors.lightBlueAccent,
+//         unselectedLabelColor: Colors.white38,
+//       ),
+//       inputDecorationTheme: InputDecorationTheme(
+//         border: OutlineInputBorder(),
+//         focusedBorder: OutlineInputBorder(
+//           borderSide: BorderSide(color: Colors.lightBlueAccent, width: 2.0),
+//         ),
+//         labelStyle: TextStyle(color: Colors.white70),
+//         hintStyle: TextStyle(color: Colors.white38),
+//       ),
+//       sliderTheme: SliderThemeData(
+//         activeTrackColor: Colors.lightBlueAccent,
+//         inactiveTrackColor: Colors.white38,
+//         thumbColor: Colors.lightBlueAccent,
+//       ),
+//       toggleableActiveColor: Colors.lightBlueAccent,
+//       // ... and any other properties you might want to override.
+//     );
+//   }
+// }

--- a/lib/core/widgets/appbar.dart
+++ b/lib/core/widgets/appbar.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:kaleidoku/core/styles/text_styles.dart';
+import 'package:kaleidoku/features/levels_screen/screens/levels_screen.dart';
 import 'package:kaleidoku/features/settings_screen/screens/settings_screen.dart';
-import 'package:kaleidoku/features/welcome_screen/screens/welcome_screen.dart';
 
 class MyAppBar extends StatelessWidget implements PreferredSizeWidget {
   final String title;
@@ -42,7 +42,7 @@ class MyAppBar extends StatelessWidget implements PreferredSizeWidget {
                 Navigator.pushAndRemoveUntil(
                     context,
                     CupertinoPageRoute(
-                        builder: (context) => const WelcomeScreen()),
+                        builder: (context) => const LevelsScreen()),
                     (route) => false);
               },
             )

--- a/lib/core/widgets/appbar.dart
+++ b/lib/core/widgets/appbar.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:kaleidoku/core/styles/text_styles.dart';
+import 'package:kaleidoku/features/settings_screen/screens/settings_screen.dart';
 import 'package:kaleidoku/features/welcome_screen/screens/welcome_screen.dart';
 
 class MyAppBar extends StatelessWidget implements PreferredSizeWidget {
@@ -24,15 +25,17 @@ class MyAppBar extends StatelessWidget implements PreferredSizeWidget {
     return AppBar(
       title: Text(
         title,
-        style: AppTextStyles().lThick.copyWith(color: Colors.black),
+        style: AppTextStyles().lThick.copyWith(
+              color: Theme.of(context).textTheme.bodyLarge!.color,
+            ),
       ),
       backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       centerTitle: true,
       leading: showMenuButton
           ? IconButton(
-              icon: const Icon(
+              icon: Icon(
                 Icons.home_outlined,
-                color: Colors.black,
+                color: Theme.of(context).iconTheme.color,
                 size: 30,
               ),
               onPressed: () {
@@ -46,22 +49,23 @@ class MyAppBar extends StatelessWidget implements PreferredSizeWidget {
           : null,
       actions: showSettingsButton
           ? [
-              const Padding(
-                padding: EdgeInsets.only(
-                  right: 12.0,
-                ),
-              ),
               Padding(
                 padding: const EdgeInsets.only(
                   right: 12.0,
                 ),
                 child: IconButton(
-                  icon: const Icon(
+                  icon: Icon(
                     Icons.settings_outlined,
-                    color: Colors.black,
+                    color: Theme.of(context).iconTheme.color,
                     size: 30,
                   ),
-                  onPressed: () {},
+                  onPressed: () {
+                    Navigator.pushAndRemoveUntil(
+                        context,
+                        CupertinoPageRoute(
+                            builder: (context) => const SettingsScreen()),
+                        (route) => false);
+                  },
                 ),
               ),
             ]

--- a/lib/features/levels_screen/screens/levels_screen.dart
+++ b/lib/features/levels_screen/screens/levels_screen.dart
@@ -22,6 +22,7 @@ class _LevelsScreenState extends State<LevelsScreen> {
     return Scaffold(
       appBar: const MyAppBar(
         title: 'Levels',
+        showMenuButton: false,
       ),
       body: BlocBuilder<PuzzleCubit, PuzzleState>(
         builder: (context, state) {

--- a/lib/features/levels_screen/screens/levels_screen.dart
+++ b/lib/features/levels_screen/screens/levels_screen.dart
@@ -26,15 +26,9 @@ class _LevelsScreenState extends State<LevelsScreen> {
       body: BlocBuilder<PuzzleCubit, PuzzleState>(
         builder: (context, state) {
           return state.maybeWhen(
-              error: (message) => Center(
-                    child: Text(message.toString()),
-                  ),
-              success: ((puzzles) => LevelScreenBody(
-                    puzzles: puzzles,
-                  )),
-              orElse: () => const Center(
-                    child: Text('Something went wrong'),
-                  ));
+              error: (message) => Center(child: Text(message.toString())),
+              success: ((puzzles) => LevelScreenBody(puzzles: puzzles)),
+              orElse: () => const Center(child: Text('Something went wrong')));
         },
       ),
     );

--- a/lib/features/settings_screen/cubits/cubit/app_settings_cubit.dart
+++ b/lib/features/settings_screen/cubits/cubit/app_settings_cubit.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:kaleidoku/core/utils/logger.dart';
+import 'package:kaleidoku/features/settings_screen/models/app_settings_model.dart';
+import 'package:kaleidoku/features/settings_screen/services/local_services/settings_hive_service.dart';
+
+part 'app_settings_state.dart';
+part 'app_settings_cubit.freezed.dart';
+
+class AppSettingsCubit extends Cubit<AppSettingsState> {
+  final SettingsHiveService service;
+  AppSettingsCubit({required this.service})
+      : super(const AppSettingsState.initial());
+
+  void getAppSettings() {
+    try {
+      logger.d('Attempting to fetch app settings');
+      emit(const AppSettingsState.loading());
+      final result = service.getAppSettings();
+      emit(AppSettingsState.success(result));
+      logger.d('Successfully fetched app settings');
+    } catch (e, st) {
+      logger.d('Error: Failed to fetch app settings', error: e, stackTrace: st);
+      emit(AppSettingsState.error(e.toString()));
+    }
+  }
+
+  Future<void> updateAppSettings({required Map<String, dynamic> item}) async {
+    try {
+      logger.d('Attempting to update app settings');
+      emit(const AppSettingsState.loading());
+      await service.updateSettings(item);
+      final result = service.getAppSettings();
+      emit(AppSettingsState.success(result));
+      logger.d('Successfully updated app settings');
+    } catch (e, st) {
+      logger.d('Error: Failed to update app settings',
+          error: e, stackTrace: st);
+      emit(AppSettingsState.error(e.toString()));
+    }
+  }
+}

--- a/lib/features/settings_screen/cubits/cubit/app_settings_cubit.freezed.dart
+++ b/lib/features/settings_screen/cubits/cubit/app_settings_cubit.freezed.dart
@@ -1,0 +1,602 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'app_settings_cubit.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+mixin _$AppSettingsState {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(String message) error,
+    required TResult Function(AppSettingsModel appSettings) success,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(String message)? error,
+    TResult? Function(AppSettingsModel appSettings)? success,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(String message)? error,
+    TResult Function(AppSettingsModel appSettings)? success,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(_Loading value) loading,
+    required TResult Function(_Error value) error,
+    required TResult Function(_Success value) success,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial value)? initial,
+    TResult? Function(_Loading value)? loading,
+    TResult? Function(_Error value)? error,
+    TResult? Function(_Success value)? success,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(_Loading value)? loading,
+    TResult Function(_Error value)? error,
+    TResult Function(_Success value)? success,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $AppSettingsStateCopyWith<$Res> {
+  factory $AppSettingsStateCopyWith(
+          AppSettingsState value, $Res Function(AppSettingsState) then) =
+      _$AppSettingsStateCopyWithImpl<$Res, AppSettingsState>;
+}
+
+/// @nodoc
+class _$AppSettingsStateCopyWithImpl<$Res, $Val extends AppSettingsState>
+    implements $AppSettingsStateCopyWith<$Res> {
+  _$AppSettingsStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+}
+
+/// @nodoc
+abstract class _$$_InitialCopyWith<$Res> {
+  factory _$$_InitialCopyWith(
+          _$_Initial value, $Res Function(_$_Initial) then) =
+      __$$_InitialCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$_InitialCopyWithImpl<$Res>
+    extends _$AppSettingsStateCopyWithImpl<$Res, _$_Initial>
+    implements _$$_InitialCopyWith<$Res> {
+  __$$_InitialCopyWithImpl(_$_Initial _value, $Res Function(_$_Initial) _then)
+      : super(_value, _then);
+}
+
+/// @nodoc
+
+class _$_Initial implements _Initial {
+  const _$_Initial();
+
+  @override
+  String toString() {
+    return 'AppSettingsState.initial()';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$_Initial);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(String message) error,
+    required TResult Function(AppSettingsModel appSettings) success,
+  }) {
+    return initial();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(String message)? error,
+    TResult? Function(AppSettingsModel appSettings)? success,
+  }) {
+    return initial?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(String message)? error,
+    TResult Function(AppSettingsModel appSettings)? success,
+    required TResult orElse(),
+  }) {
+    if (initial != null) {
+      return initial();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(_Loading value) loading,
+    required TResult Function(_Error value) error,
+    required TResult Function(_Success value) success,
+  }) {
+    return initial(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial value)? initial,
+    TResult? Function(_Loading value)? loading,
+    TResult? Function(_Error value)? error,
+    TResult? Function(_Success value)? success,
+  }) {
+    return initial?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(_Loading value)? loading,
+    TResult Function(_Error value)? error,
+    TResult Function(_Success value)? success,
+    required TResult orElse(),
+  }) {
+    if (initial != null) {
+      return initial(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Initial implements AppSettingsState {
+  const factory _Initial() = _$_Initial;
+}
+
+/// @nodoc
+abstract class _$$_LoadingCopyWith<$Res> {
+  factory _$$_LoadingCopyWith(
+          _$_Loading value, $Res Function(_$_Loading) then) =
+      __$$_LoadingCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$_LoadingCopyWithImpl<$Res>
+    extends _$AppSettingsStateCopyWithImpl<$Res, _$_Loading>
+    implements _$$_LoadingCopyWith<$Res> {
+  __$$_LoadingCopyWithImpl(_$_Loading _value, $Res Function(_$_Loading) _then)
+      : super(_value, _then);
+}
+
+/// @nodoc
+
+class _$_Loading implements _Loading {
+  const _$_Loading();
+
+  @override
+  String toString() {
+    return 'AppSettingsState.loading()';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$_Loading);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(String message) error,
+    required TResult Function(AppSettingsModel appSettings) success,
+  }) {
+    return loading();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(String message)? error,
+    TResult? Function(AppSettingsModel appSettings)? success,
+  }) {
+    return loading?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(String message)? error,
+    TResult Function(AppSettingsModel appSettings)? success,
+    required TResult orElse(),
+  }) {
+    if (loading != null) {
+      return loading();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(_Loading value) loading,
+    required TResult Function(_Error value) error,
+    required TResult Function(_Success value) success,
+  }) {
+    return loading(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial value)? initial,
+    TResult? Function(_Loading value)? loading,
+    TResult? Function(_Error value)? error,
+    TResult? Function(_Success value)? success,
+  }) {
+    return loading?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(_Loading value)? loading,
+    TResult Function(_Error value)? error,
+    TResult Function(_Success value)? success,
+    required TResult orElse(),
+  }) {
+    if (loading != null) {
+      return loading(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Loading implements AppSettingsState {
+  const factory _Loading() = _$_Loading;
+}
+
+/// @nodoc
+abstract class _$$_ErrorCopyWith<$Res> {
+  factory _$$_ErrorCopyWith(_$_Error value, $Res Function(_$_Error) then) =
+      __$$_ErrorCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String message});
+}
+
+/// @nodoc
+class __$$_ErrorCopyWithImpl<$Res>
+    extends _$AppSettingsStateCopyWithImpl<$Res, _$_Error>
+    implements _$$_ErrorCopyWith<$Res> {
+  __$$_ErrorCopyWithImpl(_$_Error _value, $Res Function(_$_Error) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? message = null,
+  }) {
+    return _then(_$_Error(
+      null == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_Error implements _Error {
+  const _$_Error(this.message);
+
+  @override
+  final String message;
+
+  @override
+  String toString() {
+    return 'AppSettingsState.error(message: $message)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_Error &&
+            (identical(other.message, message) || other.message == message));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, message);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_ErrorCopyWith<_$_Error> get copyWith =>
+      __$$_ErrorCopyWithImpl<_$_Error>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(String message) error,
+    required TResult Function(AppSettingsModel appSettings) success,
+  }) {
+    return error(message);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(String message)? error,
+    TResult? Function(AppSettingsModel appSettings)? success,
+  }) {
+    return error?.call(message);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(String message)? error,
+    TResult Function(AppSettingsModel appSettings)? success,
+    required TResult orElse(),
+  }) {
+    if (error != null) {
+      return error(message);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(_Loading value) loading,
+    required TResult Function(_Error value) error,
+    required TResult Function(_Success value) success,
+  }) {
+    return error(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial value)? initial,
+    TResult? Function(_Loading value)? loading,
+    TResult? Function(_Error value)? error,
+    TResult? Function(_Success value)? success,
+  }) {
+    return error?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(_Loading value)? loading,
+    TResult Function(_Error value)? error,
+    TResult Function(_Success value)? success,
+    required TResult orElse(),
+  }) {
+    if (error != null) {
+      return error(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Error implements AppSettingsState {
+  const factory _Error(final String message) = _$_Error;
+
+  String get message;
+  @JsonKey(ignore: true)
+  _$$_ErrorCopyWith<_$_Error> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$_SuccessCopyWith<$Res> {
+  factory _$$_SuccessCopyWith(
+          _$_Success value, $Res Function(_$_Success) then) =
+      __$$_SuccessCopyWithImpl<$Res>;
+  @useResult
+  $Res call({AppSettingsModel appSettings});
+}
+
+/// @nodoc
+class __$$_SuccessCopyWithImpl<$Res>
+    extends _$AppSettingsStateCopyWithImpl<$Res, _$_Success>
+    implements _$$_SuccessCopyWith<$Res> {
+  __$$_SuccessCopyWithImpl(_$_Success _value, $Res Function(_$_Success) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? appSettings = freezed,
+  }) {
+    return _then(_$_Success(
+      freezed == appSettings
+          ? _value.appSettings
+          : appSettings // ignore: cast_nullable_to_non_nullable
+              as AppSettingsModel,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_Success implements _Success {
+  const _$_Success(this.appSettings);
+
+  @override
+  final AppSettingsModel appSettings;
+
+  @override
+  String toString() {
+    return 'AppSettingsState.success(appSettings: $appSettings)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_Success &&
+            const DeepCollectionEquality()
+                .equals(other.appSettings, appSettings));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, const DeepCollectionEquality().hash(appSettings));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_SuccessCopyWith<_$_Success> get copyWith =>
+      __$$_SuccessCopyWithImpl<_$_Success>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(String message) error,
+    required TResult Function(AppSettingsModel appSettings) success,
+  }) {
+    return success(appSettings);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(String message)? error,
+    TResult? Function(AppSettingsModel appSettings)? success,
+  }) {
+    return success?.call(appSettings);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(String message)? error,
+    TResult Function(AppSettingsModel appSettings)? success,
+    required TResult orElse(),
+  }) {
+    if (success != null) {
+      return success(appSettings);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(_Loading value) loading,
+    required TResult Function(_Error value) error,
+    required TResult Function(_Success value) success,
+  }) {
+    return success(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial value)? initial,
+    TResult? Function(_Loading value)? loading,
+    TResult? Function(_Error value)? error,
+    TResult? Function(_Success value)? success,
+  }) {
+    return success?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(_Loading value)? loading,
+    TResult Function(_Error value)? error,
+    TResult Function(_Success value)? success,
+    required TResult orElse(),
+  }) {
+    if (success != null) {
+      return success(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Success implements AppSettingsState {
+  const factory _Success(final AppSettingsModel appSettings) = _$_Success;
+
+  AppSettingsModel get appSettings;
+  @JsonKey(ignore: true)
+  _$$_SuccessCopyWith<_$_Success> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/features/settings_screen/cubits/cubit/app_settings_cubit.freezed.dart
+++ b/lib/features/settings_screen/cubits/cubit/app_settings_cubit.freezed.dart
@@ -462,6 +462,8 @@ abstract class _$$_SuccessCopyWith<$Res> {
       __$$_SuccessCopyWithImpl<$Res>;
   @useResult
   $Res call({AppSettingsModel appSettings});
+
+  $AppSettingsModelCopyWith<$Res> get appSettings;
 }
 
 /// @nodoc
@@ -474,14 +476,22 @@ class __$$_SuccessCopyWithImpl<$Res>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? appSettings = freezed,
+    Object? appSettings = null,
   }) {
     return _then(_$_Success(
-      freezed == appSettings
+      null == appSettings
           ? _value.appSettings
           : appSettings // ignore: cast_nullable_to_non_nullable
               as AppSettingsModel,
     ));
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $AppSettingsModelCopyWith<$Res> get appSettings {
+    return $AppSettingsModelCopyWith<$Res>(_value.appSettings, (value) {
+      return _then(_value.copyWith(appSettings: value));
+    });
   }
 }
 
@@ -503,13 +513,12 @@ class _$_Success implements _Success {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_Success &&
-            const DeepCollectionEquality()
-                .equals(other.appSettings, appSettings));
+            (identical(other.appSettings, appSettings) ||
+                other.appSettings == appSettings));
   }
 
   @override
-  int get hashCode => Object.hash(
-      runtimeType, const DeepCollectionEquality().hash(appSettings));
+  int get hashCode => Object.hash(runtimeType, appSettings);
 
   @JsonKey(ignore: true)
   @override

--- a/lib/features/settings_screen/cubits/cubit/app_settings_state.dart
+++ b/lib/features/settings_screen/cubits/cubit/app_settings_state.dart
@@ -1,0 +1,10 @@
+part of 'app_settings_cubit.dart';
+
+@freezed
+class AppSettingsState with _$AppSettingsState {
+  const factory AppSettingsState.initial() = _Initial;
+  const factory AppSettingsState.loading() = _Loading;
+  const factory AppSettingsState.error(String message) = _Error;
+  const factory AppSettingsState.success(AppSettingsModel appSettings) =
+      _Success;
+}

--- a/lib/features/settings_screen/models/app_settings_model.dart
+++ b/lib/features/settings_screen/models/app_settings_model.dart
@@ -2,7 +2,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 part 'app_settings_model.g.dart';
 part 'app_settings_model.freezed.dart';
 
-@freezed
+@Freezed(fromJson: true, toJson: true)
 class AppSettingsModel with _$AppSettingsModel {
   const factory AppSettingsModel(
       {required bool isDarkTheme,

--- a/lib/features/settings_screen/models/app_settings_model.dart
+++ b/lib/features/settings_screen/models/app_settings_model.dart
@@ -1,0 +1,13 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+part 'app_settings_model.g.dart';
+part 'app_settings_model.freezed.dart';
+
+@freezed
+class AppSettingsModel with _$AppSettingsModel {
+  const factory AppSettingsModel(
+      {required bool isDarkTheme,
+      required bool isNotificationsOn}) = _AppSettingsModel;
+
+  factory AppSettingsModel.fromJson(Map<String, dynamic> json) =>
+      _$AppSettingsModelFromJson(json);
+}

--- a/lib/features/settings_screen/models/app_settings_model.freezed.dart
+++ b/lib/features/settings_screen/models/app_settings_model.freezed.dart
@@ -106,7 +106,8 @@ class __$$_AppSettingsModelCopyWithImpl<$Res>
 }
 
 /// @nodoc
-@JsonSerializable()
+
+@JsonSerializable(explicitToJson: true)
 class _$_AppSettingsModel implements _AppSettingsModel {
   const _$_AppSettingsModel(
       {required this.isDarkTheme, required this.isNotificationsOn});

--- a/lib/features/settings_screen/models/app_settings_model.freezed.dart
+++ b/lib/features/settings_screen/models/app_settings_model.freezed.dart
@@ -1,0 +1,172 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'app_settings_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+AppSettingsModel _$AppSettingsModelFromJson(Map<String, dynamic> json) {
+  return _AppSettingsModel.fromJson(json);
+}
+
+/// @nodoc
+mixin _$AppSettingsModel {
+  bool get isDarkTheme => throw _privateConstructorUsedError;
+  bool get isNotificationsOn => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $AppSettingsModelCopyWith<AppSettingsModel> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $AppSettingsModelCopyWith<$Res> {
+  factory $AppSettingsModelCopyWith(
+          AppSettingsModel value, $Res Function(AppSettingsModel) then) =
+      _$AppSettingsModelCopyWithImpl<$Res, AppSettingsModel>;
+  @useResult
+  $Res call({bool isDarkTheme, bool isNotificationsOn});
+}
+
+/// @nodoc
+class _$AppSettingsModelCopyWithImpl<$Res, $Val extends AppSettingsModel>
+    implements $AppSettingsModelCopyWith<$Res> {
+  _$AppSettingsModelCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? isDarkTheme = null,
+    Object? isNotificationsOn = null,
+  }) {
+    return _then(_value.copyWith(
+      isDarkTheme: null == isDarkTheme
+          ? _value.isDarkTheme
+          : isDarkTheme // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isNotificationsOn: null == isNotificationsOn
+          ? _value.isNotificationsOn
+          : isNotificationsOn // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_AppSettingsModelCopyWith<$Res>
+    implements $AppSettingsModelCopyWith<$Res> {
+  factory _$$_AppSettingsModelCopyWith(
+          _$_AppSettingsModel value, $Res Function(_$_AppSettingsModel) then) =
+      __$$_AppSettingsModelCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({bool isDarkTheme, bool isNotificationsOn});
+}
+
+/// @nodoc
+class __$$_AppSettingsModelCopyWithImpl<$Res>
+    extends _$AppSettingsModelCopyWithImpl<$Res, _$_AppSettingsModel>
+    implements _$$_AppSettingsModelCopyWith<$Res> {
+  __$$_AppSettingsModelCopyWithImpl(
+      _$_AppSettingsModel _value, $Res Function(_$_AppSettingsModel) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? isDarkTheme = null,
+    Object? isNotificationsOn = null,
+  }) {
+    return _then(_$_AppSettingsModel(
+      isDarkTheme: null == isDarkTheme
+          ? _value.isDarkTheme
+          : isDarkTheme // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isNotificationsOn: null == isNotificationsOn
+          ? _value.isNotificationsOn
+          : isNotificationsOn // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_AppSettingsModel implements _AppSettingsModel {
+  const _$_AppSettingsModel(
+      {required this.isDarkTheme, required this.isNotificationsOn});
+
+  factory _$_AppSettingsModel.fromJson(Map<String, dynamic> json) =>
+      _$$_AppSettingsModelFromJson(json);
+
+  @override
+  final bool isDarkTheme;
+  @override
+  final bool isNotificationsOn;
+
+  @override
+  String toString() {
+    return 'AppSettingsModel(isDarkTheme: $isDarkTheme, isNotificationsOn: $isNotificationsOn)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_AppSettingsModel &&
+            (identical(other.isDarkTheme, isDarkTheme) ||
+                other.isDarkTheme == isDarkTheme) &&
+            (identical(other.isNotificationsOn, isNotificationsOn) ||
+                other.isNotificationsOn == isNotificationsOn));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, isDarkTheme, isNotificationsOn);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_AppSettingsModelCopyWith<_$_AppSettingsModel> get copyWith =>
+      __$$_AppSettingsModelCopyWithImpl<_$_AppSettingsModel>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_AppSettingsModelToJson(
+      this,
+    );
+  }
+}
+
+abstract class _AppSettingsModel implements AppSettingsModel {
+  const factory _AppSettingsModel(
+      {required final bool isDarkTheme,
+      required final bool isNotificationsOn}) = _$_AppSettingsModel;
+
+  factory _AppSettingsModel.fromJson(Map<String, dynamic> json) =
+      _$_AppSettingsModel.fromJson;
+
+  @override
+  bool get isDarkTheme;
+  @override
+  bool get isNotificationsOn;
+  @override
+  @JsonKey(ignore: true)
+  _$$_AppSettingsModelCopyWith<_$_AppSettingsModel> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/features/settings_screen/models/app_settings_model.g.dart
+++ b/lib/features/settings_screen/models/app_settings_model.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: non_constant_identifier_names
+
+part of 'app_settings_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_AppSettingsModel _$$_AppSettingsModelFromJson(Map<String, dynamic> json) =>
+    _$_AppSettingsModel(
+      isDarkTheme: json['isDarkTheme'] as bool,
+      isNotificationsOn: json['isNotificationsOn'] as bool,
+    );
+
+Map<String, dynamic> _$$_AppSettingsModelToJson(_$_AppSettingsModel instance) =>
+    <String, dynamic>{
+      'isDarkTheme': instance.isDarkTheme,
+      'isNotificationsOn': instance.isNotificationsOn,
+    };

--- a/lib/features/settings_screen/screens/settings_screen.dart
+++ b/lib/features/settings_screen/screens/settings_screen.dart
@@ -1,0 +1,176 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_email_sender/flutter_email_sender.dart';
+import 'package:kaleidoku/core/styles/sizes.dart';
+import 'package:kaleidoku/core/styles/text_styles.dart';
+import 'package:kaleidoku/core/utils/validators.dart';
+import 'package:kaleidoku/core/widgets/app_button.dart';
+import 'package:kaleidoku/core/widgets/appbar.dart';
+import 'package:kaleidoku/features/settings_screen/cubits/cubit/app_settings_cubit.dart';
+import 'package:kaleidoku/features/settings_screen/widgets/notification_switch.dart';
+import 'package:kaleidoku/features/settings_screen/widgets/theme_switch.dart';
+
+class SettingsScreen extends StatelessWidget {
+  const SettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      appBar: MyAppBar(
+          title: 'Settings', showMenuButton: true, showSettingsButton: false),
+      body: SettingsScreenBody(),
+    );
+  }
+}
+
+class SettingsScreenBody extends StatefulWidget {
+  const SettingsScreenBody({super.key});
+
+  @override
+  State<SettingsScreenBody> createState() => _SettingsScreenBodyState();
+}
+
+class _SettingsScreenBodyState extends State<SettingsScreenBody> {
+  final _feedbackController = TextEditingController();
+  String feedbackSubject = 'Other';
+  bool isLoading = false;
+  final _formKey = GlobalKey<FormState>();
+
+  @override
+  void initState() {
+    super.initState();
+    context.read<AppSettingsCubit>().getAppSettings();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Form(
+      key: _formKey,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: PaddingSizes.mdl),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text("App Settings", style: AppTextStyles().lThick),
+            const SizedBox(height: PaddingSizes.mdl),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text("Dark Theme", style: AppTextStyles().mThick),
+                const SizedBox(width: PaddingSizes.xxs),
+                BlocBuilder<AppSettingsCubit, AppSettingsState>(
+                  builder: (context, state) {
+                    return state.maybeWhen(
+                        success: (appSettings) {
+                          return ThemeSwitch(appSettingsModel: appSettings);
+                        },
+                        orElse: () => const SizedBox.shrink());
+                  },
+                ),
+              ],
+            ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text("Notifications", style: AppTextStyles().mThick),
+                const SizedBox(width: PaddingSizes.xxs),
+                BlocBuilder<AppSettingsCubit, AppSettingsState>(
+                  builder: (context, state) {
+                    return state.maybeWhen(
+                        success: (appSettings) {
+                          return NotificationSwitch(
+                              appSettingsModel: appSettings);
+                        },
+                        orElse: () => const SizedBox.shrink());
+                  },
+                ),
+              ],
+            ),
+            const SizedBox(height: PaddingSizes.mdl),
+            Text("Feedback", style: AppTextStyles().lThick),
+            const SizedBox(height: PaddingSizes.mdl),
+            Text('Request Help', style: AppTextStyles().mThick),
+            const SizedBox(height: PaddingSizes.xs),
+            DropdownButtonFormField(
+                decoration: const InputDecoration(
+                    focusedBorder: OutlineInputBorder(
+                        borderSide: BorderSide(color: Colors.grey)),
+                    border: OutlineInputBorder(
+                        borderSide: BorderSide(color: Colors.grey))),
+                hint: const Text('Type of request'),
+                items: const [
+                  DropdownMenuItem(
+                      value: 'Help using the product',
+                      child: Text('Help using the product')),
+                  DropdownMenuItem(
+                      value: 'Report an issue', child: Text('Report an issue')),
+                  DropdownMenuItem(
+                      value: 'Improvement Request',
+                      child: Text('Improvement Request')),
+                  DropdownMenuItem(value: 'Other', child: Text('Other')),
+                ],
+                onChanged: ((value) {
+                  feedbackSubject = value!;
+                })),
+            const SizedBox(height: PaddingSizes.xs),
+            TextFormField(
+              validator: validateField,
+              controller: _feedbackController,
+              maxLines: 6,
+              decoration: const InputDecoration(
+                  hintText: 'How can we help you?',
+                  contentPadding: EdgeInsets.symmetric(
+                      vertical: PaddingSizes.sm, horizontal: PaddingSizes.sm),
+                  border: OutlineInputBorder(
+                    borderSide: BorderSide(color: Colors.grey),
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderSide: BorderSide(color: Colors.grey),
+                  )),
+            ),
+            const SizedBox(height: PaddingSizes.sm),
+            isLoading
+                ? const CircularProgressIndicator()
+                : AppButton(
+                    onTap: () async {
+                      if (_formKey.currentState!.validate()) {
+                        setState(() {
+                          isLoading = true;
+                        });
+                        final Email email = Email(
+                          body: _feedbackController.text.trim(),
+                          subject: feedbackSubject,
+                          recipients: ['jaredezzethasson@gmail.com'],
+                          isHTML: false,
+                        );
+
+                        try {
+                          await FlutterEmailSender.send(email);
+                        } catch (e) {
+                          if (e is PlatformException &&
+                              e.code == "not_available") {
+                            if (!mounted) return;
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(
+                                content: Text("No email clients available!"),
+                              ),
+                            );
+                          } else {
+                            rethrow;
+                          }
+                        } finally {
+                          setState(() {
+                            isLoading = false;
+                          });
+                        }
+                      }
+                    },
+                    title: 'Submit',
+                  )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/settings_screen/services/local_services/settings_hive_service.dart
+++ b/lib/features/settings_screen/services/local_services/settings_hive_service.dart
@@ -9,9 +9,13 @@ class SettingsHiveService {
   final _settings = Hive.box('appSettings');
 
   Future<void> updateSettings(Map<String, dynamic> item) async {
-    logger.d('Updating settings');
-    await _settings.put('appSettings', item);
-    logger.d('Successfully updated settings');
+    try {
+      logger.d('Updating settings');
+      await _settings.put('appSettings', item);
+      logger.d('Successfully updated settings');
+    } catch (e, st) {
+      logger.d('Failed to update settings', error: e, stackTrace: st);
+    }
   }
 
   AppSettingsModel getAppSettings() {

--- a/lib/features/settings_screen/services/local_services/settings_hive_service.dart
+++ b/lib/features/settings_screen/services/local_services/settings_hive_service.dart
@@ -4,9 +4,10 @@ import 'package:hive_flutter/hive_flutter.dart';
 import 'package:kaleidoku/core/utils/logger.dart';
 import 'package:kaleidoku/core/utils/parser.dart';
 import 'package:kaleidoku/features/settings_screen/models/app_settings_model.dart';
+import 'package:kaleidoku/features/settings_screen/utils/consts.dart';
 
 class SettingsHiveService {
-  final _settings = Hive.box('appSettings');
+  final _settings = Hive.box(APP_SETTINGS_BOX);
 
   Future<void> updateSettings(Map<String, dynamic> item) async {
     try {

--- a/lib/features/settings_screen/services/local_services/settings_hive_service.dart
+++ b/lib/features/settings_screen/services/local_services/settings_hive_service.dart
@@ -1,0 +1,25 @@
+import 'dart:async';
+
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:kaleidoku/core/utils/logger.dart';
+import 'package:kaleidoku/core/utils/parser.dart';
+import 'package:kaleidoku/features/settings_screen/models/app_settings_model.dart';
+
+class SettingsHiveService {
+  final _settings = Hive.box('appSettings');
+
+  Future<void> updateSettings(Map<String, dynamic> item) async {
+    logger.d('Updating settings');
+    await _settings.put('appSettings', item);
+    logger.d('Successfully updated settings');
+  }
+
+  AppSettingsModel getAppSettings() {
+    final defaultSettingsAdded = _settings.get('appSettings', defaultValue: {
+      "isDarkTheme": false,
+      "isNotificationsOn": false,
+    });
+
+    return AppSettingsModel.fromJson(parser(defaultSettingsAdded));
+  }
+}

--- a/lib/features/settings_screen/utils/consts.dart
+++ b/lib/features/settings_screen/utils/consts.dart
@@ -1,0 +1,3 @@
+// ignore_for_file: constant_identifier_names
+
+const String APP_SETTINGS_BOX = 'appSettings';

--- a/lib/features/settings_screen/widgets/notification_switch.dart
+++ b/lib/features/settings_screen/widgets/notification_switch.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:kaleidoku/features/settings_screen/cubits/cubit/app_settings_cubit.dart';
+import 'package:kaleidoku/features/settings_screen/models/app_settings_model.dart';
+
+class NotificationSwitch extends StatefulWidget {
+  final AppSettingsModel appSettingsModel;
+
+  const NotificationSwitch({super.key, required this.appSettingsModel});
+
+  @override
+  ThemeSwitchState createState() => ThemeSwitchState();
+}
+
+class ThemeSwitchState extends State<NotificationSwitch> {
+  bool _isDarkTheme = false;
+  bool _isNotificationOn = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _isDarkTheme = widget.appSettingsModel.isDarkTheme;
+    _isNotificationOn = widget.appSettingsModel.isNotificationsOn;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Switch(
+      value: _isNotificationOn,
+      onChanged: (value) {
+        setState(() {
+          _isNotificationOn = value;
+        });
+
+        context.read<AppSettingsCubit>().updateAppSettings(
+            item: {"isNotificationsOn": value, "isDarkTheme": _isDarkTheme});
+      },
+    );
+  }
+}

--- a/lib/features/settings_screen/widgets/theme_switch.dart
+++ b/lib/features/settings_screen/widgets/theme_switch.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:kaleidoku/features/settings_screen/cubits/cubit/app_settings_cubit.dart';
+import 'package:kaleidoku/features/settings_screen/models/app_settings_model.dart';
+
+class ThemeSwitch extends StatefulWidget {
+  final AppSettingsModel appSettingsModel;
+
+  const ThemeSwitch({super.key, required this.appSettingsModel});
+
+  @override
+  ThemeSwitchState createState() => ThemeSwitchState();
+}
+
+class ThemeSwitchState extends State<ThemeSwitch> {
+  bool _isDarkTheme = false;
+  bool _isNotificationOn = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _isDarkTheme = widget.appSettingsModel.isDarkTheme;
+    _isNotificationOn = widget.appSettingsModel.isNotificationsOn;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Switch(
+      value: _isDarkTheme,
+      onChanged: (value) {
+        setState(() {
+          _isDarkTheme = value;
+        });
+
+        context.read<AppSettingsCubit>().updateAppSettings(item: {
+          "isNotificationsOn": _isNotificationOn,
+          "isDarkTheme": value
+        });
+      },
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -230,6 +230,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.1.3"
+  flutter_email_sender:
+    dependency: "direct main"
+    description:
+      name: flutter_email_sender
+      sha256: "52b713a67a966be4d9e6f68a323fc0a5bc2da71c567eb451af1aa90d30adbc3a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.1"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   freezed_annotation: ^2.4.1
   hive_flutter: ^1.1.0
   flutter_bloc: ^8.1.3
+  flutter_email_sender: ^6.0.1
 
 
 dev_dependencies:


### PR DESCRIPTION
- Settings Page UI
- Dark/Light theme switch & functionality
- Notifications switch
- App settings (Theme and notifications switch) saved to hive
- Feedback/Report to Email



<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Added a settings page with options for dark/light theme and notifications.
- New Feature: Implemented functionality to save app settings (theme and notifications) using Hive.
- New Feature: Introduced a feedback/report feature via email.
- Refactor: Improved code readability in the `BlocBuilder` widget within the `LevelsScreen`.
- Chore: Added `<queries>` section to the Android manifest file to handle email intents.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->